### PR TITLE
Updates OCLint output regex to make Description group optional.

### DIFF
--- a/libcassowary/src/lint/linter/ArcanistOCLinter.php
+++ b/libcassowary/src/lint/linter/ArcanistOCLinter.php
@@ -96,7 +96,7 @@ final class ArcanistOCLinter extends ArcanistLinter {
 
         foreach ($stdout as $line) {
             $matches = array();
-            if ($c = preg_match_all("/((?:\\/[\\w\\.\\-]+)+):(\\d+):(\\d+): (.*?) P(\\d+)((?:[a-zA-Z0-9 ]+))/is",
+            if ($c = preg_match_all("/((?:\\/[\\w\\.\\-]+)+):(\\d+):(\\d+): (.*?) P(\\d+)((?:[a-zA-Z0-9 ]+))?/is",
                 $line, $matches)) {
                 $message = new ArcanistLintMessage();
                 $message->setPath($path);


### PR DESCRIPTION
Some OCLint Rules do not supply a description. As such they are not matched by the regex. The last description group is optional and so now includes those results when adding lint messages.